### PR TITLE
[feat](#11) 사용자 퀴즈 제출 기록 조회 (mongodb + graphQL) 구현

### DIFF
--- a/src/main/java/com/poweranger/hai_duo/quiz/api/controller/QuizController.java
+++ b/src/main/java/com/poweranger/hai_duo/quiz/api/controller/QuizController.java
@@ -19,8 +19,7 @@ public class QuizController {
 
     @PostMapping("/submit")
     public ApiResponse<SubmitQuizResultDto> submitQuiz(@RequestBody SubmitQuizInputDto input) {
-        boolean isCorrect = quizSubmissionService.isCorrect(input.stageId(), input.quizType(), input.selectedOption());
-        quizSubmissionService.submitQuiz(input);
+        boolean isCorrect = quizSubmissionService.submitQuiz(input);
         return ApiResponse.onSuccess(new SubmitQuizResultDto(isCorrect));
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/quiz/api/dto/SubmitQuizInputDto.java
+++ b/src/main/java/com/poweranger/hai_duo/quiz/api/dto/SubmitQuizInputDto.java
@@ -5,5 +5,5 @@ public record SubmitQuizInputDto (
         Long stageId,
         String quizType,
         String selectedOption,
-        String elapsedTime
+        Float responseTime
 ){}

--- a/src/main/java/com/poweranger/hai_duo/quiz/api/resolver/QuizAnswerResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/quiz/api/resolver/QuizAnswerResolver.java
@@ -1,0 +1,34 @@
+package com.poweranger.hai_duo.quiz.api.resolver;
+
+import com.poweranger.hai_duo.global.exception.GeneralException;
+import com.poweranger.hai_duo.global.response.code.ErrorStatus;
+import com.poweranger.hai_duo.quiz.domain.repository.QuizBlankRepository;
+import com.poweranger.hai_duo.quiz.domain.repository.QuizCardRepository;
+import com.poweranger.hai_duo.quiz.domain.repository.QuizMeaningRepository;
+import com.poweranger.hai_duo.quiz.domain.repository.QuizOXRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuizAnswerResolver {
+
+    private final QuizMeaningRepository quizMeaningRepository;
+    private final QuizCardRepository quizCardRepository;
+    private final QuizOXRepository quizOXRepository;
+    private final QuizBlankRepository quizBlankRepository;
+
+    public String resolveCorrectAnswer(Long stageId, String quizType) {
+        return switch (quizType) {
+            case "MEAN" -> quizMeaningRepository.findByStage_StageId(stageId)
+                    .orElseThrow().getWord();
+            case "CARD" -> quizCardRepository.findByStage_StageId(stageId)
+                    .orElseThrow().getCorrectWord();
+            case "OX" -> String.valueOf(quizOXRepository.findByStage_StageId(stageId)
+                    .orElseThrow().getWord());
+            case "BLANK" -> quizBlankRepository.findByStage_StageId(stageId)
+                    .orElseThrow().getCorrectWord();
+            default -> throw new GeneralException(ErrorStatus.QUIZ_TYPE_NOT_FOUND);
+        };
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/quiz/api/resolver/QuizQueryResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/quiz/api/resolver/QuizQueryResolver.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
-
 import java.util.List;
 
 @Controller

--- a/src/main/java/com/poweranger/hai_duo/quiz/application/service/QuizSubmissionService.java
+++ b/src/main/java/com/poweranger/hai_duo/quiz/application/service/QuizSubmissionService.java
@@ -1,35 +1,48 @@
 package com.poweranger.hai_duo.quiz.application.service;
 
-import com.poweranger.hai_duo.global.exception.GeneralException;
-import com.poweranger.hai_duo.global.response.code.ErrorStatus;
 import com.poweranger.hai_duo.quiz.api.dto.SubmitQuizInputDto;
+import com.poweranger.hai_duo.quiz.api.resolver.QuizAnswerResolver;
+import com.poweranger.hai_duo.quiz.domain.entity.QuizType;
 import com.poweranger.hai_duo.quiz.domain.repository.*;
+import com.poweranger.hai_duo.user.domain.entity.mongodb.UserProgressLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class QuizSubmissionService {
 
     private final QuizLogRepository quizLogRepository;
-    private final QuizMeaningRepository quizMeaningRepository;
-    private final QuizCardRepository quizCardRepository;
-    private final QuizOXRepository quizOXRepository;
-    private final QuizBlankRepository quizBlankRepository;
+    private final QuizAnswerResolver quizAnswerResolver;
 
-    public void submitQuiz(SubmitQuizInputDto input) {
-        quizLogRepository.save(input);
+    public boolean submitQuiz(SubmitQuizInputDto input) {
+        String correctAnswer = getCorrectAnswer(input);
+        boolean isCorrect = checkAnswerCorrectness(correctAnswer, input.selectedOption());
+
+        saveUserProgressLog(input, correctAnswer, isCorrect);
+        return isCorrect;
     }
 
-    public boolean isCorrect(Long stageId, String quizType, String selectedOption) {
-        String correctAnswer = switch (quizType) {
-            case "MEAN" -> quizMeaningRepository.findByStage_StageId(stageId).orElseThrow().getWord();
-            case "CARD" -> quizCardRepository.findByStage_StageId(stageId).orElseThrow().getCorrectWord();
-            case "OX" -> String.valueOf(quizOXRepository.findByStage_StageId(stageId).orElseThrow().getWord());
-            case "BLANK" -> quizBlankRepository.findByStage_StageId(stageId).orElseThrow().getCorrectWord();
-            default -> throw new GeneralException(ErrorStatus.QUIZ_TYPE_NOT_FOUND);
-        };
+    private String getCorrectAnswer(SubmitQuizInputDto input) {
+        return quizAnswerResolver.resolveCorrectAnswer(input.stageId(), input.quizType());
+    }
+
+    private boolean checkAnswerCorrectness(String correctAnswer, String selectedOption) {
         return correctAnswer.equals(selectedOption);
+    }
+
+    private void saveUserProgressLog(SubmitQuizInputDto input, String correctAnswer, boolean isCorrect) {
+        UserProgressLog log = new UserProgressLog(
+                input.userId(),
+                input.stageId(),
+                QuizType.valueOf(input.quizType()),
+                isCorrect,
+                input.selectedOption(),
+                correctAnswer,
+                input.responseTime(),
+                LocalDateTime.now()
+        );
+        quizLogRepository.save(log);
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/quiz/domain/repository/QuizLogRepository.java
+++ b/src/main/java/com/poweranger/hai_duo/quiz/domain/repository/QuizLogRepository.java
@@ -1,13 +1,9 @@
 package com.poweranger.hai_duo.quiz.domain.repository;
 
-import com.poweranger.hai_duo.quiz.api.dto.SubmitQuizInputDto;
+import com.poweranger.hai_duo.user.domain.entity.mongodb.UserProgressLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Repository;
-
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -15,15 +11,8 @@ public class QuizLogRepository {
 
     private final MongoTemplate mongoTemplate;
 
-    public void save(SubmitQuizInputDto input) {
-        Map<String, Object> doc = new HashMap<>();
-        doc.put("userId", input.userId());
-        doc.put("stageId", input.stageId());
-        doc.put("quizType", input.quizType());
-        doc.put("selectedOption", input.selectedOption());
-        doc.put("elapsedTime", input.elapsedTime());
-        doc.put("submittedAt", Instant.now());
-
-        mongoTemplate.save(doc, "user_quiz_logs");
+    public void save(UserProgressLog log) {
+        mongoTemplate.save(log);
     }
+
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/controller/UserProgressController.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/controller/UserProgressController.java
@@ -1,11 +1,11 @@
-package com.poweranger.hai_duo.progress.api.controller;
+package com.poweranger.hai_duo.user.api.controller;
 
 import com.poweranger.hai_duo.global.response.ApiResponse;
 import com.poweranger.hai_duo.progress.api.dto.ChapterResponseDto;
 import com.poweranger.hai_duo.progress.api.dto.LevelResponseDto;
 import com.poweranger.hai_duo.progress.api.dto.ProgressResponseDto;
 import com.poweranger.hai_duo.progress.api.dto.StageResponseDto;
-import com.poweranger.hai_duo.progress.application.service.UserProgressService;
+import com.poweranger.hai_duo.user.application.service.UserProgressService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/poweranger/hai_duo/user/api/dto/UserDto.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/dto/UserDto.java
@@ -1,9 +1,6 @@
 package com.poweranger.hai_duo.user.api.dto;
 
 import java.time.LocalDateTime;
-
-import com.poweranger.hai_duo.progress.domain.entity.GameCharacter;
-import com.poweranger.hai_duo.progress.domain.entity.Level;
 import com.poweranger.hai_duo.user.domain.entity.mysql.User;
 
 public record UserDto(
@@ -11,8 +8,8 @@ public record UserDto(
         String tempUserToken,
         int exp,
         int goldAmount,
-        Level levelId,
-        GameCharacter characterId,
+        Long levelId,
+        Long characterId,
         LocalDateTime createdAt,
         LocalDateTime lastAccessedAt
 ) {
@@ -22,8 +19,8 @@ public record UserDto(
                 user.getTempUserToken(),
                 user.getExp(),
                 user.getGoldAmount(),
-                user.getLevel(),
-                user.getGameCharacter(),
+                user.getLevel().getLevelId(),
+                user.getGameCharacter().getCharacterId(),
                 user.getCreatedAt(),
                 user.getLastAccessedAt()
         );

--- a/src/main/java/com/poweranger/hai_duo/user/api/dto/UserProgressLogDto.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/dto/UserProgressLogDto.java
@@ -1,0 +1,18 @@
+package com.poweranger.hai_duo.user.api.dto;
+
+import com.poweranger.hai_duo.quiz.domain.entity.QuizType;
+
+import java.time.LocalDateTime;
+
+public record UserProgressLogDto(
+        String id,
+        Long userId,
+        Long stageId,
+        QuizType quizType,
+        boolean isCorrect,
+        String selectedOption,
+        String answer,
+        Float responseTime,
+        LocalDateTime answeredAt
+) {
+}

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserProgressQueryResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserProgressQueryResolver.java
@@ -1,0 +1,22 @@
+package com.poweranger.hai_duo.user.api.resolver;
+
+import com.poweranger.hai_duo.user.domain.entity.mongodb.UserProgressLog;
+import com.poweranger.hai_duo.user.domain.repository.UserProgressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class UserProgressQueryResolver {
+
+    private final UserProgressRepository userProgressRepository;
+
+    @QueryMapping
+    public List<UserProgressLog> getUserQuizLogs(@Argument Long userId) {
+        return userProgressRepository.findByUserId(userId);
+    }
+
+}

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserQueryResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserQueryResolver.java
@@ -17,4 +17,5 @@ public class UserQueryResolver {
     public UserDto getUserById(@Argument Long userId) {
         return userService.getUserDtoById(userId);
     }
+
 }

--- a/src/main/java/com/poweranger/hai_duo/user/application/service/UserProgressService.java
+++ b/src/main/java/com/poweranger/hai_duo/user/application/service/UserProgressService.java
@@ -1,4 +1,4 @@
-package com.poweranger.hai_duo.progress.application.service;
+package com.poweranger.hai_duo.user.application.service;
 
 import com.poweranger.hai_duo.global.exception.GeneralException;
 import com.poweranger.hai_duo.global.response.code.ErrorStatus;
@@ -11,7 +11,8 @@ import com.poweranger.hai_duo.progress.api.dto.LevelResponseDto;
 import com.poweranger.hai_duo.progress.api.dto.ProgressResponseDto;
 import com.poweranger.hai_duo.progress.api.dto.StageResponseDto;
 import com.poweranger.hai_duo.progress.api.factory.ProgressDtoFactory;
-import com.poweranger.hai_duo.user.domain.entity.mongodb.UserQuizLog;
+import com.poweranger.hai_duo.user.api.dto.UserProgressLogDto;
+import com.poweranger.hai_duo.user.domain.entity.mongodb.UserProgressLog;
 import com.poweranger.hai_duo.user.domain.entity.mysql.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,17 +32,17 @@ public class UserProgressService {
     private final ProgressDtoFactory progressDtoFactory;
 
     public Long getLatestStageIdFromLog(Long userId) {
-        UserQuizLog log = mongoTemplate.findOne(
+        UserProgressLog log = mongoTemplate.findOne(
                 Query.query(Criteria.where("userId").is(userId))
                         .with(Sort.by(Sort.Direction.DESC, "answeredAt"))
                         .limit(1),
-                UserQuizLog.class
+                UserProgressLog.class
         );
         validateLogExists(log);
         return log.getStageId();
     }
 
-    private void validateLogExists(UserQuizLog log) {
+    private void validateLogExists(UserProgressLog log) {
         if (log == null) {
             throw new GeneralException(ErrorStatus.QUIZ_NOT_FOUND);
         }
@@ -74,4 +77,5 @@ public class UserProgressService {
         Long stageId = getLatestStageIdFromLog(userId);
         return progressReader.getStage(stageId);
     }
+
 }

--- a/src/main/java/com/poweranger/hai_duo/user/domain/entity/mongodb/UserProgressLog.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/entity/mongodb/UserProgressLog.java
@@ -3,19 +3,20 @@ package com.poweranger.hai_duo.user.domain.entity.mongodb;
 import com.poweranger.hai_duo.quiz.domain.entity.QuizType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@Document(collection = "user_quiz_logs")
-public class UserQuizLog {
+@Document(collection = "user_progress_logs")
+public class UserProgressLog {
 
     @Id
-    private String id;
+    private ObjectId id;
 
-    private String userId;
+    private Long userId;
     private Long stageId;
 
     private QuizType quizType;
@@ -24,15 +25,17 @@ public class UserQuizLog {
     private String selectedOption;
     private String answer;
 
+    private Float responseTime;
     private LocalDateTime answeredAt;
 
-    public UserQuizLog(
-            String userId,
+    public UserProgressLog(
+            Long userId,
             Long stageId,
             QuizType quizType,
             boolean isCorrect,
             String selectedOption,
             String answer,
+            float responseTime,
             LocalDateTime answeredAt
     ) {
         this.userId = userId;
@@ -41,6 +44,7 @@ public class UserQuizLog {
         this.isCorrect = isCorrect;
         this.selectedOption = selectedOption;
         this.answer = answer;
+        this.responseTime = responseTime;
         this.answeredAt = answeredAt;
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserProgressRepository.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserProgressRepository.java
@@ -1,0 +1,9 @@
+package com.poweranger.hai_duo.user.domain.repository;
+
+import com.poweranger.hai_duo.user.domain.entity.mongodb.UserProgressLog;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import java.util.List;
+
+public interface UserProgressRepository extends MongoRepository<UserProgressLog, Long> {
+    List<UserProgressLog> findByUserId(Long userId);
+}

--- a/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserRepository.java
@@ -7,7 +7,5 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
     Optional<User> findByTempUserToken(String tempUserId);
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/graphql/common.graphqls
+++ b/src/main/resources/graphql/common.graphqls
@@ -1,0 +1,6 @@
+enum QuizType {
+    MEAN
+    CARD
+    OX
+    BLANK
+}

--- a/src/main/resources/graphql/quiz.graphqls
+++ b/src/main/resources/graphql/quiz.graphqls
@@ -42,11 +42,4 @@ type QuizBlankDto {
     correctWord: String!
 }
 
-enum QuizType {
-    MEAN
-    CARD
-    OX
-    BLANK
-}
-
 union QuizUnionDto = QuizMeaningDto | QuizCardDto | QuizOXDto | QuizBlankDto

--- a/src/main/resources/graphql/user.graphqls
+++ b/src/main/resources/graphql/user.graphqls
@@ -5,6 +5,7 @@ type Mutation {
 
 type Query {
   getUserById(userId: ID!): UserDto
+  getUserQuizLogs(userId: ID!): [UserProgressLog!]!
 }
 
 type UserDto {
@@ -29,4 +30,16 @@ type LevelUpResultDto {
 type CharacterDto {
   characterId: ID!
   characterName: String!
+}
+
+type UserProgressLog {
+  id: ID!
+  userId: ID!
+  stageId: ID!
+  quizType: QuizType!
+  isCorrect: Boolean!
+  selectedOption: String!
+  answer: String!
+  responseTime: Float!
+  answeredAt: String!
 }


### PR DESCRIPTION
## 📌 주요 변경 사항

- `user_progress_logs` 컬렉션 기반으로 사용자 퀴즈 응답 이력을 조회하는 기능 추가
- GraphQL Query: `getUserQuizLogs(userId: ID!): [UserProgressLog!]!` 구현
- MongoDB 연동을 위한 `UserProgressLog` 엔티티 정의
- 정답 여부 및 정답 문자열(`answer`) 포함
- `QuizSubmissionService`에서 정답 조회 및 `UserProgressLog` 저장 책임 분리
- 레포지토리는 단순 저장만 담당 (SRP 적용)

## 🧩 세부 구현

### ✅ GraphQL
- `user.graphqls`에 `getUserQuizLogs` 쿼리 추가
- 반환 타입 `UserProgressLog`에 `answer`, `responseTime`, `answeredAt` 포함

### ✅ MongoDB Entity
- `UserProgressLog` 클래스 생성 (컬렉션: `user_progress_logs`)
- DTO: `UserProgressLogDto`를 `record`로 정의하여 응답 최적화

### ✅ Service Layer
- `QuizSubmissionService.submitQuiz`에서 정답 확인 후 `UserProgressLog` 객체 생성
- `UserProgressLogRepository.save()`는 도메인 객체를 그대로 저장 (역할 분리)

## 🧪 테스트
<img width="1286" alt="스크린샷 2025-05-17 오후 7 39 14" src="https://github.com/user-attachments/assets/66fe7b30-3a1f-4ac4-99d9-c0ea1a30f697" />
