### PR TITLE
[Feat](#17) 사용자 연속 학습일 조회

### DIFF
--- a/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.poweranger.hai_duo.user.api.controller;
 
+import com.poweranger.hai_duo.global.response.ApiResponse;
 import com.poweranger.hai_duo.user.api.dto.UserDto;
+import com.poweranger.hai_duo.user.api.dto.UserStreakDto;
 import com.poweranger.hai_duo.user.application.service.UserService;
+import com.poweranger.hai_duo.user.application.service.UserStreakService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,9 +14,15 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserStreakService userStreakService;
 
     @PostMapping("/temp")
     public UserDto createTempUser() {
         return userService.createTempUser();
+    }
+
+    @GetMapping("/{userId}/streak")
+    public ApiResponse<UserStreakDto> getUserStreak(@PathVariable Long userId) {
+        return userStreakService.getUserStreak(userId);
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/dto/UserStreakDto.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/dto/UserStreakDto.java
@@ -1,0 +1,13 @@
+package com.poweranger.hai_duo.user.api.dto;
+
+public record UserStreakDto(
+        Long userId,
+        int streakCount
+) {
+    public static UserStreakDto from(Long userId, int streakCount) {
+        return new UserStreakDto(
+                userId,
+                streakCount
+        );
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/user/application/service/UserAccuracyService.java
+++ b/src/main/java/com/poweranger/hai_duo/user/application/service/UserAccuracyService.java
@@ -2,7 +2,6 @@ package com.poweranger.hai_duo.user.application.service;
 
 import com.poweranger.hai_duo.global.exception.GeneralException;
 import com.poweranger.hai_duo.global.response.code.ErrorStatus;
-import com.poweranger.hai_duo.progress.domain.repository.LevelRepository;
 import com.poweranger.hai_duo.progress.domain.repository.StageRepository;
 import com.poweranger.hai_duo.user.api.dto.UserAccuracyByChapterDto;
 import com.poweranger.hai_duo.user.api.dto.UserAccuracyByLevelDto;
@@ -24,7 +23,6 @@ public class UserAccuracyService {
     private final MongoTemplate mongoTemplate;
     private final StageRepository stageRepository;
     private final UserAccuracyDtoFactory userAccuracyDtoFactory;
-    private final LevelRepository levelRepository;
 
     public UserAccuracyDto getUserAccuracy(Long userId) {
         Aggregation aggregation = buildUserAggregation(userId);

--- a/src/main/java/com/poweranger/hai_duo/user/application/service/UserStreakService.java
+++ b/src/main/java/com/poweranger/hai_duo/user/application/service/UserStreakService.java
@@ -1,0 +1,89 @@
+package com.poweranger.hai_duo.user.application.service;
+
+import com.poweranger.hai_duo.global.response.ApiResponse;
+import com.poweranger.hai_duo.user.api.dto.UserStreakDto;
+import lombok.RequiredArgsConstructor;
+import org.bson.Document;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserStreakService {
+
+    private final MongoTemplate mongoTemplate;
+
+    public ApiResponse<UserStreakDto> getUserStreak(Long userId) {
+        List<LocalDate> dates = fetchAnsweredDates(userId);
+        int streak = calculateStreakCount(dates);
+        return ApiResponse.onSuccess(UserStreakDto.from(userId, streak));
+    }
+
+    private List<LocalDate> fetchAnsweredDates(Long userId) {
+        Aggregation aggregation = buildAnsweredDateAggregation(userId);
+        return extractDatesFromAggregation(aggregation);
+    }
+
+    private Aggregation buildAnsweredDateAggregation(Long userId) {
+        ProjectionOperation project = project()
+                .andExpression("userId").as("userId")
+                .andExpression("dateToString('%Y-%m-%d', answeredAt)").as("date");
+
+        return newAggregation(
+                match(Criteria.where("userId").is(userId)),
+                project,
+                group("date").first("date").as("date"),
+                sort(Sort.Direction.DESC, "date")
+        );
+    }
+
+    private List<LocalDate> extractDatesFromAggregation(Aggregation aggregation) {
+        AggregationResults<Document> results =
+                mongoTemplate.aggregate(aggregation, "user_progress_logs", Document.class);
+
+        return results.getMappedResults().stream()
+                .map(doc -> LocalDate.parse(doc.getString("date"), DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .toList();
+    }
+
+    private int calculateStreakCount(List<LocalDate> dates) {
+        if (dates.isEmpty()) {
+            return 0;
+        }
+        if (!isToday(dates.get(0))) {
+            return 0;
+        }
+        return countConsecutiveDates(dates);
+    }
+
+    private boolean isToday(LocalDate date) {
+        return date.equals(LocalDate.now());
+    }
+
+    private int countConsecutiveDates(List<LocalDate> dates) {
+        if (dates.isEmpty()) {
+            return 0;
+        }
+
+        int count = 1;
+
+        for (int i = 1; i < dates.size(); i++) {
+            LocalDate yesterday = dates.get(i - 1).minusDays(1);
+            boolean isConsecutive = dates.get(i).equals(yesterday);
+            if (!isConsecutive) return count;
+            count++;
+        }
+
+        return count;
+    }
+
+}

--- a/src/main/java/com/poweranger/hai_duo/user/domain/entity/mongodb/UserProgressLog.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/entity/mongodb/UserProgressLog.java
@@ -4,6 +4,7 @@ import com.poweranger.hai_duo.quiz.domain.entity.QuizType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDateTime;
@@ -27,6 +28,8 @@ public class UserProgressLog {
     private String answer;
 
     private Float responseTime;
+
+    @CreatedDate
     private LocalDateTime answeredAt;
 
     public UserProgressLog(


### PR DESCRIPTION
## 요약
- 사용자가 최근 며칠 동안 연속으로 학습했는지 계산
- MongoDB의 user_progress_logs 컬렉션을 활용하여 오늘 날짜부터 시작되는 연속 학습 일수를 추출
<br><br>

## 작업 내용
- MongoTemplate 기반 Aggregation으로 사용자의 학습 날짜 리스트 추출
- 날짜 정렬 및 연속성 계산 로직 추가 (countConsecutiveDates)
- UserStreakDto 반환 구조 적용
- 응답을 ApiResponse<UserStreakDto> 형식으로 래핑하여 일관된 응답 포맷 유지
- SOLID 원칙에 따라 메서드 SRP 분리 적용 (Aggregation/계산/변환 로직 나눔)
<br><br>

## 참고 사항
- 날짜는 'yyyy-MM-dd' 포맷으로 answeredAt에서 변환해 사용
- 오늘 날짜로 시작되지 않으면 streak는 0으로 간주
<img width="1003" alt="스크린샷 2025-05-18 오후 6 50 35" src="https://github.com/user-attachments/assets/2274b8c4-b2fe-4cc8-8207-b8035c1ecb35" />
<br><br>

## 관련 이슈
- Close #17 

<br><br>
